### PR TITLE
add netExp_trace option to GlobalMetabolicNetwork.expand

### DIFF
--- a/examples/fold_expansion_27Jan21.ipynb
+++ b/examples/fold_expansion_27Jan21.ipynb
@@ -1409,9 +1409,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (network_expansion3)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "network_expansion3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1423,7 +1423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/networkExpansionPy/lib.py
+++ b/networkExpansionPy/lib.py
@@ -401,8 +401,8 @@ class GlobalMetabolicNetwork:
         
         if algorithm.lower() == 'trace':
     
-            compound_iteration_dict = self.create_iteration_dict(self,X,self.idx_to_cid)
-            reaction_iteration_dict = self.create_iteration_dict(self,Y,self.idx_to_rid)
+            compound_iteration_dict = self.create_iteration_dict(X,self.idx_to_cid)
+            reaction_iteration_dict = self.create_iteration_dict(Y,self.idx_to_rid)
             return compound_iteration_dict, reaction_iteration_dict
 
         else:

--- a/networkExpansionPy/lib.py
+++ b/networkExpansionPy/lib.py
@@ -380,9 +380,30 @@ class GlobalMetabolicNetwork:
             x,y = netExp(R,P,x0,b)
         elif algorithm.lower() == 'cr':
             x,y = netExp_cr(R,P,x0,b)
+        elif algorithm.lower() == 'trace':
+            X,Y = netExp_trace(R,P,x0,b)
         else:
             raise ValueError('algorithm needs to be naive (compound stopping criteria) or cr (reaction/compound stopping criteria)')
         
+        if algorithm.lower() == 'trace':
+            idx_iter = dict()
+            for i,x in enumerate(X):
+                idxs = np.nonzero(x.toarray().T[0])[0]
+                for idx in idxs:
+                    if idx not in idx_iter:
+                        idx_iter[idx] = i
+
+            # compounds = []
+            # cpditeration = []
+            # for idx,i in idx_iter.items():
+            #     compounds.append(self.idx_to_cid[idx])
+            #     cpditeration.append(i)  
+            cid_iter = dict()
+            for idx,i in idx_iter.items():
+                cid_iter[self.idx_to_cid[idx]] = i  
+
+        return X
+
         # convert to list of metabolite ids and reaction ids
         if x.toarray().sum() > 0:
             cidx = np.nonzero(x.toarray().T[0])[0]
@@ -397,4 +418,3 @@ class GlobalMetabolicNetwork:
             reactions = [];
             
         return compounds,reactions
-

--- a/networkExpansionPy/lib.py
+++ b/networkExpansionPy/lib.py
@@ -400,31 +400,10 @@ class GlobalMetabolicNetwork:
             raise ValueError('algorithm needs to be naive (compound stopping criteria) or cr (reaction/compound stopping criteria)')
         
         if algorithm.lower() == 'trace':
-            # idx_iter = dict()
-            # for i,x in enumerate(X):
-            #     idxs = np.nonzero(x.toarray().T[0])[0]
-            #     for idx in idxs:
-            #         if idx not in idx_iter:
-            #             idx_iter[idx] = i
-
-            # cid_iter = dict()
-            # for idx,i in idx_iter.items():
-            #     cid_iter[self.idx_to_cid[idx]] = i  
-
-            self.create_iteration_dict(self,X,self.idx_to_cid)
-
-            # idx_iter = dict()
-            # for i,x in enumerate(X):
-            #     idxs = np.nonzero(x.toarray().T[0])[0]
-            #     for idx in idxs:
-            #         if idx not in idx_iter:
-            #             idx_iter[idx] = i
-
-            # cid_iter = dict()
-            # for idx,i in idx_iter.items():
-            #     cid_iter[self.idx_to_cid[idx]] = i  
-
-           self.create_iteration_dict(self,Y,self.idx_to_rid)
+    
+            compound_iteration_dict = self.create_iteration_dict(self,X,self.idx_to_cid)
+            reaction_iteration_dict = self.create_iteration_dict(self,Y,self.idx_to_rid)
+            return compound_iteration_dict, reaction_iteration_dict
 
         else:
             # convert to list of metabolite ids and reaction ids

--- a/networkExpansionPy/lib.py
+++ b/networkExpansionPy/lib.py
@@ -354,6 +354,20 @@ class GlobalMetabolicNetwork:
             S[self.cid_to_idx[c],self.rid_to_idx[(r,d)]] = s
 
         return S
+
+    def create_iteration_dict(self,M,idx_to_id):
+        idx_iter = dict()
+        for i,row in enumerate(M):
+            idxs = np.nonzero(row.toarray().T[0])[0]
+            for idx in idxs:
+                if idx not in idx_iter:
+                    idx_iter[idx] = i
+
+        id_iter = dict()
+        for idx,i in idx_iter.items():
+            id_iter[idx_to_id[idx]] = i  
+
+        return id_iter
         
     def expand(self,seedSet,algorithm='naive'):
         # constructre network from skinny table and create matricies for NE algorithm
@@ -386,35 +400,44 @@ class GlobalMetabolicNetwork:
             raise ValueError('algorithm needs to be naive (compound stopping criteria) or cr (reaction/compound stopping criteria)')
         
         if algorithm.lower() == 'trace':
-            idx_iter = dict()
-            for i,x in enumerate(X):
-                idxs = np.nonzero(x.toarray().T[0])[0]
-                for idx in idxs:
-                    if idx not in idx_iter:
-                        idx_iter[idx] = i
+            # idx_iter = dict()
+            # for i,x in enumerate(X):
+            #     idxs = np.nonzero(x.toarray().T[0])[0]
+            #     for idx in idxs:
+            #         if idx not in idx_iter:
+            #             idx_iter[idx] = i
 
-            # compounds = []
-            # cpditeration = []
+            # cid_iter = dict()
             # for idx,i in idx_iter.items():
-            #     compounds.append(self.idx_to_cid[idx])
-            #     cpditeration.append(i)  
-            cid_iter = dict()
-            for idx,i in idx_iter.items():
-                cid_iter[self.idx_to_cid[idx]] = i  
+            #     cid_iter[self.idx_to_cid[idx]] = i  
 
-        return X
+            self.create_iteration_dict(self,X,self.idx_to_cid)
 
-        # convert to list of metabolite ids and reaction ids
-        if x.toarray().sum() > 0:
-            cidx = np.nonzero(x.toarray().T[0])[0]
-            compounds = [self.idx_to_cid[i] for i in cidx]
+            # idx_iter = dict()
+            # for i,x in enumerate(X):
+            #     idxs = np.nonzero(x.toarray().T[0])[0]
+            #     for idx in idxs:
+            #         if idx not in idx_iter:
+            #             idx_iter[idx] = i
+
+            # cid_iter = dict()
+            # for idx,i in idx_iter.items():
+            #     cid_iter[self.idx_to_cid[idx]] = i  
+
+           self.create_iteration_dict(self,Y,self.idx_to_rid)
+
         else:
-            compounds = []
-            
-        if y.toarray().sum() > 0:
-            ridx = np.nonzero(y.toarray().T[0])[0]
-            reactions = [self.idx_to_rid[i] for i in ridx]
-        else:
-            reactions = [];
-            
-        return compounds,reactions
+            # convert to list of metabolite ids and reaction ids
+            if x.toarray().sum() > 0:
+                cidx = np.nonzero(x.toarray().T[0])[0]
+                compounds = [self.idx_to_cid[i] for i in cidx]
+            else:
+                compounds = []
+                
+            if y.toarray().sum() > 0:
+                ridx = np.nonzero(y.toarray().T[0])[0]
+                reactions = [self.idx_to_rid[i] for i in ridx]
+            else:
+                reactions = [];
+                
+            return compounds,reactions

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -127,11 +127,15 @@ class Test_create_iteration_dict(unittest.TestCase):
         self.X,self.Y = ne.netExp_trace(R,P,x0,b)
     
     def test_iteration_dict(self):
-        compound_iteration_dict = self.kegg.create_iteration_dict(self.X,self.kegg.idx_to_cid)
+        compound_iteration_dict = self.kegg.create_iteration_dict(self.X, self.kegg.idx_to_cid)
+        reaction_iteration_dict = self.kegg.create_iteration_dict(self.Y, self.kegg.idx_to_rid)
 
         ## Look through iteration 0 compounds and make sure its exactly equal to seed set
-        self.
+        self.assertEqual(set([k for k,v in compound_iteration_dict.items() if v==0]), set(self.seedSet))
 
         ## Check that matrix has exactlly two more rows than max(idx_iter.values())
-
+        self.assertEqual(len(self.X)-2, max(compound_iteration_dict.values()) )
+        self.assertEqual(len(self.Y)-2, max(reaction_iteration_dict.values()) )
         ## Check that all iterations are present in at least 1 compound in the iteration dict
+        self.assertEqual(len(self.X)-2, len(set(compound_iteration_dict.values())) )
+        self.assertEqual(len(self.Y)-2, len(set(reaction_iteration_dict.values())) )

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -3,98 +3,99 @@ import networkExpansionPy.lib as ne
 import pandas as pd
 from scipy.sparse import csr_matrix
 
-class TestGlobalMetabolicNetworkInit(unittest.TestCase):
+# class TestGlobalMetabolicNetworkInit(unittest.TestCase):
 
-    def test_kegg_og_no_args(self):
-        kegg_og = ne.GlobalMetabolicNetwork()
-        self.assertEqual(kegg_og.metabolism,"KEGG_OG")
-        self.assertIsInstance(kegg_og.network,pd.core.frame.DataFrame)
+#     def test_kegg_og_no_args(self):
+#         kegg_og = ne.GlobalMetabolicNetwork()
+#         self.assertEqual(kegg_og.metabolism,"KEGG_OG")
+#         self.assertIsInstance(kegg_og.network,pd.core.frame.DataFrame)
         
-        nsize = len(kegg_og.network)
-        self.assertGreater(nsize,1)
+#         nsize = len(kegg_og.network)
+#         self.assertGreater(nsize,1)
         
-        kegg_og.pruneUnbalancedReactions()
-        nsize_ubpruned = len(kegg_og.network)
-        self.assertLessEqual(nsize_ubpruned,nsize)
+#         kegg_og.pruneUnbalancedReactions()
+#         nsize_ubpruned = len(kegg_og.network)
+#         self.assertLessEqual(nsize_ubpruned,nsize)
         
-        kegg_og.pruneInconsistentReactions()
-        nsize_inconpruned = len(kegg_og.network)
-        self.assertLessEqual(nsize_inconpruned,nsize_ubpruned)
+#         kegg_og.pruneInconsistentReactions()
+#         nsize_inconpruned = len(kegg_og.network)
+#         self.assertLessEqual(nsize_inconpruned,nsize_ubpruned)
 
-        kegg_og.set_ph(7.0)
-        self.assertIsInstance(kegg_og.thermo,pd.core.frame.DataFrame)
+#         kegg_og.set_ph(7.0)
+#         self.assertIsInstance(kegg_og.thermo,pd.core.frame.DataFrame)
 
-        kegg_og.convertToIrreversible()
-        self.assertEqual(len(kegg_og.network),2*nsize_inconpruned)
+#         kegg_og.convertToIrreversible()
+#         self.assertEqual(len(kegg_og.network),2*nsize_inconpruned)
 
-        kegg_og.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-        self.assertIn("ub",kegg_og.network)
-        self.assertIn("lb",kegg_og.network)
+#         kegg_og.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+#         self.assertIn("ub",kegg_og.network)
+#         self.assertIn("lb",kegg_og.network)
 
-        nsize_prethermoprune = len(kegg_og.network)
-        kegg_og.pruneThermodynamicallyInfeasibleReactions(keepnan=False)
-        self.assertLessEqual(len(kegg_og.network),nsize_prethermoprune)
+#         nsize_prethermoprune = len(kegg_og.network)
+#         kegg_og.pruneThermodynamicallyInfeasibleReactions(keepnan=False)
+#         self.assertLessEqual(len(kegg_og.network),nsize_prethermoprune)
 
-    def test_ecg(self):
-        ecg = ne.GlobalMetabolicNetwork("ecg")
-        self.assertEqual(ecg.metabolism,"ecg")
-        self.assertIsInstance(ecg.network,pd.core.frame.DataFrame)
+#     def test_ecg(self):
+#         ecg = ne.GlobalMetabolicNetwork("ecg")
+#         self.assertEqual(ecg.metabolism,"ecg")
+#         self.assertIsInstance(ecg.network,pd.core.frame.DataFrame)
         
-        nsize = len(ecg.network)
-        self.assertGreater(nsize,1)
+#         nsize = len(ecg.network)
+#         self.assertGreater(nsize,1)
         
-        with self.assertRaises(NotImplementedError):
-            ecg.pruneUnbalancedReactions()
+#         with self.assertRaises(NotImplementedError):
+#             ecg.pruneUnbalancedReactions()
 
-        ecg.pruneInconsistentReactions()
-        nsize_inconpruned = len(ecg.network)
-        self.assertLessEqual(nsize_inconpruned,nsize)
+#         ecg.pruneInconsistentReactions()
+#         nsize_inconpruned = len(ecg.network)
+#         self.assertLessEqual(nsize_inconpruned,nsize)
 
-        with self.assertRaises(ValueError):
-            ecg.set_ph(7.0)
+#         with self.assertRaises(ValueError):
+#             ecg.set_ph(7.0)
 
-        ecg.convertToIrreversible()
-        self.assertEqual(len(ecg.network),2*nsize_inconpruned)
+#         ecg.convertToIrreversible()
+#         self.assertEqual(len(ecg.network),2*nsize_inconpruned)
 
-        ecg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-        self.assertIn("ub",ecg.network)
-        self.assertIn("lb",ecg.network)
+#         ecg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+#         self.assertIn("ub",ecg.network)
+#         self.assertIn("lb",ecg.network)
 
-        with self.assertRaises(AttributeError):
-            ecg.pruneThermodynamicallyInfeasibleReactions()
+#         with self.assertRaises(AttributeError):
+#             ecg.pruneThermodynamicallyInfeasibleReactions()
 
-    def test_KEGG(self):
-        kegg = ne.GlobalMetabolicNetwork("KEGG")
-        self.assertEqual(kegg.metabolism,"KEGG")
-        self.assertIsInstance(kegg.network,pd.core.frame.DataFrame)
+#     def test_KEGG(self):
+#         kegg = ne.GlobalMetabolicNetwork("KEGG")
+#         self.assertEqual(kegg.metabolism,"KEGG")
+#         self.assertIsInstance(kegg.network,pd.core.frame.DataFrame)
         
-        nsize = len(kegg.network)
-        self.assertGreater(nsize,1)
+#         nsize = len(kegg.network)
+#         self.assertGreater(nsize,1)
         
-        with self.assertRaises(NotImplementedError):
-            kegg.pruneUnbalancedReactions()
+#         with self.assertRaises(NotImplementedError):
+#             kegg.pruneUnbalancedReactions()
 
-        kegg.pruneInconsistentReactions()
-        nsize_inconpruned = len(kegg.network)
-        self.assertLessEqual(nsize_inconpruned,nsize)
+#         kegg.pruneInconsistentReactions()
+#         nsize_inconpruned = len(kegg.network)
+#         self.assertLessEqual(nsize_inconpruned,nsize)
 
-        with self.assertRaises(NotImplementedError):
-            kegg.set_ph(7.0)
+#         with self.assertRaises(NotImplementedError):
+#             kegg.set_ph(7.0)
 
-        kegg.convertToIrreversible()
-        self.assertEqual(len(kegg.network),2*nsize_inconpruned)
+#         kegg.convertToIrreversible()
+#         self.assertEqual(len(kegg.network),2*nsize_inconpruned)
 
-        kegg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-        self.assertIn("ub",kegg.network)
-        self.assertIn("lb",kegg.network)
+#         kegg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+#         self.assertIn("ub",kegg.network)
+#         self.assertIn("lb",kegg.network)
 
-        with self.assertRaises(AttributeError):
-            kegg.pruneThermodynamicallyInfeasibleReactions()
+#         with self.assertRaises(AttributeError):
+#             kegg.pruneThermodynamicallyInfeasibleReactions()
 
 class Test_create_iteration_dict(unittest.TestCase):
 
-    @classmethod
-    def setup_class(self):
+    # @classmethod
+    # def setup_class(self):
+    def setUp(self):
         self.kegg = ne.GlobalMetabolicNetwork("KEGG")
         self.kegg.pruneInconsistentReactions()
         self.kegg.convertToIrreversible()
@@ -135,7 +136,7 @@ class Test_create_iteration_dict(unittest.TestCase):
 
         ## Check that matrix has exactlly two more rows than max(idx_iter.values())
         self.assertEqual(len(self.X)-2, max(compound_iteration_dict.values()) )
-        self.assertEqual(len(self.Y)-2, max(reaction_iteration_dict.values()) )
+        self.assertEqual(len(self.Y)-1, max(reaction_iteration_dict.values()) )
         ## Check that all iterations are present in at least 1 compound in the iteration dict
-        self.assertEqual(len(self.X)-2, len(set(compound_iteration_dict.values())) )
-        self.assertEqual(len(self.Y)-2, len(set(reaction_iteration_dict.values())) )
+        self.assertEqual(len(self.X)-1, len(set(compound_iteration_dict.values())) )
+        self.assertEqual(len(self.Y)-1, len(set(reaction_iteration_dict.values())) )

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -1,6 +1,7 @@
 import unittest
 import networkExpansionPy.lib as ne
 import pandas as pd
+from scipy.sparse import csr_matrix
 
 class TestGlobalMetabolicNetworkInit(unittest.TestCase):
 
@@ -89,3 +90,48 @@ class TestGlobalMetabolicNetworkInit(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             kegg.pruneThermodynamicallyInfeasibleReactions()
+
+class Test_create_iteration_dict(unittest.TestCase):
+
+    @classmethod
+    def setup_class(self):
+        self.kegg = ne.GlobalMetabolicNetwork("KEGG")
+        self.kegg.pruneInconsistentReactions()
+        self.kegg.convertToIrreversible()
+        self.seedSet = ["C00001",
+                "C00011",
+                "C00014",
+                "C00033",
+                "C00058",
+                "C00283",
+                "C00288",
+                "C00697"]
+
+        self.kegg.rid_to_idx, self.kegg.idx_to_rid = self.kegg.create_reaction_dicts()
+        self.kegg.cid_to_idx, self.kegg.idx_to_cid = self.kegg.create_compound_dicts()
+        self.kegg.S = self.kegg.create_S_from_irreversible_network()
+        x0 = self.kegg.initialize_metabolite_vector(self.seedSet)
+        R = (self.kegg.S < 0)*1
+        P = (self.kegg.S > 0)*1
+        b = sum(R)
+
+        # sparsefy data
+        R = csr_matrix(R)
+        P = csr_matrix(P)
+        b = csr_matrix(b)
+        b = b.transpose()
+
+        x0 = csr_matrix(x0)
+        x0 = x0.transpose()
+
+        self.X,self.Y = ne.netExp_trace(R,P,x0,b)
+    
+    def test_iteration_dict(self):
+        compound_iteration_dict = self.kegg.create_iteration_dict(self.X,self.kegg.idx_to_cid)
+
+        ## Look through iteration 0 compounds and make sure its exactly equal to seed set
+        self.
+
+        ## Check that matrix has exactlly two more rows than max(idx_iter.values())
+
+        ## Check that all iterations are present in at least 1 compound in the iteration dict

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -3,93 +3,93 @@ import networkExpansionPy.lib as ne
 import pandas as pd
 from scipy.sparse import csr_matrix
 
-# class TestGlobalMetabolicNetworkInit(unittest.TestCase):
+class TestGlobalMetabolicNetworkInit(unittest.TestCase):
 
-#     def test_kegg_og_no_args(self):
-#         kegg_og = ne.GlobalMetabolicNetwork()
-#         self.assertEqual(kegg_og.metabolism,"KEGG_OG")
-#         self.assertIsInstance(kegg_og.network,pd.core.frame.DataFrame)
+    def test_kegg_og_no_args(self):
+        kegg_og = ne.GlobalMetabolicNetwork()
+        self.assertEqual(kegg_og.metabolism,"KEGG_OG")
+        self.assertIsInstance(kegg_og.network,pd.core.frame.DataFrame)
         
-#         nsize = len(kegg_og.network)
-#         self.assertGreater(nsize,1)
+        nsize = len(kegg_og.network)
+        self.assertGreater(nsize,1)
         
-#         kegg_og.pruneUnbalancedReactions()
-#         nsize_ubpruned = len(kegg_og.network)
-#         self.assertLessEqual(nsize_ubpruned,nsize)
+        kegg_og.pruneUnbalancedReactions()
+        nsize_ubpruned = len(kegg_og.network)
+        self.assertLessEqual(nsize_ubpruned,nsize)
         
-#         kegg_og.pruneInconsistentReactions()
-#         nsize_inconpruned = len(kegg_og.network)
-#         self.assertLessEqual(nsize_inconpruned,nsize_ubpruned)
+        kegg_og.pruneInconsistentReactions()
+        nsize_inconpruned = len(kegg_og.network)
+        self.assertLessEqual(nsize_inconpruned,nsize_ubpruned)
 
-#         kegg_og.set_ph(7.0)
-#         self.assertIsInstance(kegg_og.thermo,pd.core.frame.DataFrame)
+        kegg_og.set_ph(7.0)
+        self.assertIsInstance(kegg_og.thermo,pd.core.frame.DataFrame)
 
-#         kegg_og.convertToIrreversible()
-#         self.assertEqual(len(kegg_og.network),2*nsize_inconpruned)
+        kegg_og.convertToIrreversible()
+        self.assertEqual(len(kegg_og.network),2*nsize_inconpruned)
 
-#         kegg_og.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-#         self.assertIn("ub",kegg_og.network)
-#         self.assertIn("lb",kegg_og.network)
+        kegg_og.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+        self.assertIn("ub",kegg_og.network)
+        self.assertIn("lb",kegg_og.network)
 
-#         nsize_prethermoprune = len(kegg_og.network)
-#         kegg_og.pruneThermodynamicallyInfeasibleReactions(keepnan=False)
-#         self.assertLessEqual(len(kegg_og.network),nsize_prethermoprune)
+        nsize_prethermoprune = len(kegg_og.network)
+        kegg_og.pruneThermodynamicallyInfeasibleReactions(keepnan=False)
+        self.assertLessEqual(len(kegg_og.network),nsize_prethermoprune)
 
-#     def test_ecg(self):
-#         ecg = ne.GlobalMetabolicNetwork("ecg")
-#         self.assertEqual(ecg.metabolism,"ecg")
-#         self.assertIsInstance(ecg.network,pd.core.frame.DataFrame)
+    def test_ecg(self):
+        ecg = ne.GlobalMetabolicNetwork("ecg")
+        self.assertEqual(ecg.metabolism,"ecg")
+        self.assertIsInstance(ecg.network,pd.core.frame.DataFrame)
         
-#         nsize = len(ecg.network)
-#         self.assertGreater(nsize,1)
+        nsize = len(ecg.network)
+        self.assertGreater(nsize,1)
         
-#         with self.assertRaises(NotImplementedError):
-#             ecg.pruneUnbalancedReactions()
+        with self.assertRaises(NotImplementedError):
+            ecg.pruneUnbalancedReactions()
 
-#         ecg.pruneInconsistentReactions()
-#         nsize_inconpruned = len(ecg.network)
-#         self.assertLessEqual(nsize_inconpruned,nsize)
+        ecg.pruneInconsistentReactions()
+        nsize_inconpruned = len(ecg.network)
+        self.assertLessEqual(nsize_inconpruned,nsize)
 
-#         with self.assertRaises(ValueError):
-#             ecg.set_ph(7.0)
+        with self.assertRaises(ValueError):
+            ecg.set_ph(7.0)
 
-#         ecg.convertToIrreversible()
-#         self.assertEqual(len(ecg.network),2*nsize_inconpruned)
+        ecg.convertToIrreversible()
+        self.assertEqual(len(ecg.network),2*nsize_inconpruned)
 
-#         ecg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-#         self.assertIn("ub",ecg.network)
-#         self.assertIn("lb",ecg.network)
+        ecg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+        self.assertIn("ub",ecg.network)
+        self.assertIn("lb",ecg.network)
 
-#         with self.assertRaises(AttributeError):
-#             ecg.pruneThermodynamicallyInfeasibleReactions()
+        with self.assertRaises(AttributeError):
+            ecg.pruneThermodynamicallyInfeasibleReactions()
 
-#     def test_KEGG(self):
-#         kegg = ne.GlobalMetabolicNetwork("KEGG")
-#         self.assertEqual(kegg.metabolism,"KEGG")
-#         self.assertIsInstance(kegg.network,pd.core.frame.DataFrame)
+    def test_KEGG(self):
+        kegg = ne.GlobalMetabolicNetwork("KEGG")
+        self.assertEqual(kegg.metabolism,"KEGG")
+        self.assertIsInstance(kegg.network,pd.core.frame.DataFrame)
         
-#         nsize = len(kegg.network)
-#         self.assertGreater(nsize,1)
+        nsize = len(kegg.network)
+        self.assertGreater(nsize,1)
         
-#         with self.assertRaises(NotImplementedError):
-#             kegg.pruneUnbalancedReactions()
+        with self.assertRaises(NotImplementedError):
+            kegg.pruneUnbalancedReactions()
 
-#         kegg.pruneInconsistentReactions()
-#         nsize_inconpruned = len(kegg.network)
-#         self.assertLessEqual(nsize_inconpruned,nsize)
+        kegg.pruneInconsistentReactions()
+        nsize_inconpruned = len(kegg.network)
+        self.assertLessEqual(nsize_inconpruned,nsize)
 
-#         with self.assertRaises(NotImplementedError):
-#             kegg.set_ph(7.0)
+        with self.assertRaises(NotImplementedError):
+            kegg.set_ph(7.0)
 
-#         kegg.convertToIrreversible()
-#         self.assertEqual(len(kegg.network),2*nsize_inconpruned)
+        kegg.convertToIrreversible()
+        self.assertEqual(len(kegg.network),2*nsize_inconpruned)
 
-#         kegg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
-#         self.assertIn("ub",kegg.network)
-#         self.assertIn("lb",kegg.network)
+        kegg.setMetaboliteBounds(ub=1e-1,lb=1e-6)
+        self.assertIn("ub",kegg.network)
+        self.assertIn("lb",kegg.network)
 
-#         with self.assertRaises(AttributeError):
-#             kegg.pruneThermodynamicallyInfeasibleReactions()
+        with self.assertRaises(AttributeError):
+            kegg.pruneThermodynamicallyInfeasibleReactions()
 
 class Test_create_iteration_dict(unittest.TestCase):
 


### PR DESCRIPTION
When expanding, this makes it possible to easily track the iteration that compounds and reactions appear during an expansion. When calling `metabolism.expand(seedSet,algorithm="trace")`, the output is a dict of compounds:iteration and a dict of reactions:iteration instead of a list of compounds and list of reactions, as with the other algorithms. 

e.g.
```
>>> compound_iteration_dict, reaction_iteration_dict = metabolism.expand(seedSet, algorithm="trace")
>>> compound_iteration_dict
{'C00288': 0,
 'C00058': 0,
 'C00697': 0,
 ...
 'C01898': 1,
 'C11552': 1,
 'C15584': 1,
 ...}
```