### PR TITLE
Scopeiter

### DIFF
--- a/examples/profiling_example-look_ahead.py
+++ b/examples/profiling_example-look_ahead.py
@@ -1,0 +1,82 @@
+import warnings
+warnings.filterwarnings("ignore")
+import networkExpansionPy.folds as nf
+import networkExpansionPy.lib as ne
+import pandas as pd
+from pathlib import PurePath, Path
+import random
+from copy import copy
+import sys
+
+seed = sys.argv[1]
+random.seed(seed)
+asset_path = nf.asset_path
+ALGORITHM = "look_ahead_rules" #"random_fold_order"
+WRITE = True # write result to disk
+WRITE_TMP = True # write after each iteration
+CUSTOM_WRITE_PATH = None # if writing result, custom path to write to
+STR_TO_APPEND_TO_FNAME = str(Path(__file__).stem)+"_%s"%seed # if writing result, str to append to filename
+
+METABOLISM_PATH = PurePath(asset_path, "metabolic_networks","metabolism.23Aug2022.pkl") # path to metabolism object pickle
+RN2RULES_PATH = PurePath(asset_path, "rn2fold","rn2rules.20230224.pkl") # path to rn2rules object pickle
+SEED_CPDS_PATH = PurePath(asset_path, "compounds", "seeds.Goldford2022.csv") # path to seed compounds csv
+
+ORDERED_OUTCOME = False # ignore random seed and always choose folds based on sort order
+IGNORE_REACTION_VERSIONS = True # when maximizing for reactions, don't count versioned reactions
+
+## Metabolism
+metabolism = pd.read_pickle(METABOLISM_PATH)
+
+## FoldRules
+rn2rules = pd.read_pickle(RN2RULES_PATH)
+foldrules = nf.FoldRules.from_rn2rules(rn2rules)
+popular_folds = set([
+    2002,
+    2007,
+    7560,
+    543,
+    210,
+    325,
+    205,
+    282,
+    246,
+    109])
+popular_folds = set(str(i) for i in popular_folds)
+foldrules = foldrules.subset_from_folds(popular_folds)
+
+## Modify seeds with AA and GATP_rns
+aa_cids = set(["C00037",
+    "C00041",
+    "C00065",
+    "C00188",
+    "C00183",
+    "C00407",
+    "C00123",
+    "C00148",
+    "C00049",
+    "C00025"])
+
+GATP_rns = {'R00200_gATP_v1',
+    'R00200_gATP_v2',
+    'R00430_gGTP_v1',
+    'R00430_gGTP_v2',
+    'R01523_gATP_v1',
+    'R04144_gATP_v1',
+    'R04208_gATP',
+    'R04463_gATP',
+    'R04591_gATP_v1',
+    'R06836_gATP',
+    'R06974_gATP',
+    'R06975_gATP_v1'}
+
+## Seed
+seed = nf.Params(
+    rns = set(metabolism.network["rn"]) - set(rn2rules) | GATP_rns,
+    cpds = set((pd.read_csv(SEED_CPDS_PATH)["ID"])) | aa_cids,
+    folds = set(['spontaneous'])
+)
+
+## Inititalize fold metabolism
+fm = nf.FoldMetabolism(metabolism, foldrules, seed)
+## Run fold expansion
+result = fm.rule_order(algorithm=ALGORITHM, write=WRITE, write_tmp=WRITE_TMP, path=CUSTOM_WRITE_PATH, str_to_append_to_fname=STR_TO_APPEND_TO_FNAME, ordered_outcome=ORDERED_OUTCOME, ignore_reaction_versions=IGNORE_REACTION_VERSIONS)

--- a/networkExpansionPy/folds.py
+++ b/networkExpansionPy/folds.py
@@ -164,6 +164,7 @@ class Result:
 
         self.max_effects = dict()
         self.size2foldsets = dict()
+        self.eq_best_folds = dict()
 
     def first_update(self, current, metadata=None, write=False, path=None, str_to_append_to_fname=None):
         self.update_cpds(current)
@@ -177,9 +178,10 @@ class Result:
         self.update_iter()
         self.update_folds(current)
         self.update_rules(current)
-        if metadata.max_effects != None: self.update_max_effects(metadata)
-        if metadata.size2foldsets != None: self.update_size2foldsets(metadata)
-        if metadata.eq_best_folds != None: self.update_eq_best_folds(metadata)
+        if metadata != None:
+            if metadata.max_effects != None: self.update_max_effects(metadata)
+            if metadata.size2foldsets != None: self.update_size2foldsets(metadata)
+            if metadata.eq_best_folds != None: self.update_eq_best_folds(metadata)
         self.first_update(current, write=write, path=path, str_to_append_to_fname=str_to_append_to_fname)
 
     def update_cpds(self, current):
@@ -580,9 +582,9 @@ class FoldMetabolism:
             max_foldset2key_counts = {k:v for k, v in foldset2key_count.items() if v==max_v and max_v>0}
             
             print("+++++++++++++++++")
-            pprint(f"foldset2key_count: {foldset2key_count}")
+            # pprint(f"foldset2key_count: {foldset2key_count}")
             print(f"max_v: {max_v}")
-            pprint(f"max_foldsets:\n\t{max_foldsets}")
+            print(f"max_foldsets:\n\t{max_foldsets}")
             if max_v>0:
                 break
         

--- a/networkExpansionPy/folds.py
+++ b/networkExpansionPy/folds.py
@@ -654,6 +654,9 @@ class FoldMetabolism:
                 else: # n_new < max_v or n_new == max_v == 0
                     pass
 
+            print("+++++++++++++++++")
+            print(f"max_v: {max_v}")
+            print(f"max_foldsets:\n\t{list(max_effects.keys())}")
             ## Don't look for longer rules if shorter rules enable new reactions
             if max_v>0:
                 break

--- a/networkExpansionPy/folds.py
+++ b/networkExpansionPy/folds.py
@@ -105,6 +105,7 @@ class Metadata:
     def __init__(self):
         self.size2foldsets = None
         self.max_effects = None
+        self.eq_best_folds = None
 
 class Result:
     """
@@ -176,9 +177,9 @@ class Result:
         self.update_iter()
         self.update_folds(current)
         self.update_rules(current)
-        if metadata != None:
-            self.update_max_effects(metadata)
-            self.update_size2foldsets(metadata)
+        if metadata.max_effects != None: self.update_max_effects(metadata)
+        if metadata.size2foldsets != None: self.update_size2foldsets(metadata)
+        if metadata.eq_best_folds != None: self.update_eq_best_folds(metadata)
         self.first_update(current, write=write, path=path, str_to_append_to_fname=str_to_append_to_fname)
 
     def update_cpds(self, current):
@@ -220,6 +221,9 @@ class Result:
 
     def update_size2foldsets(self, metadata):
         self.size2foldsets[self.iteration] = metadata.size2foldsets
+
+    def update_eq_best_folds(self, metadata):
+        self.eq_best_folds[self.iteration] = metadata.eq_best_folds
 
     def update_iter(self):
         self.iteration+=1
@@ -464,15 +468,18 @@ class FoldMetabolism:
         """
         print("calculating scope...")
         rn_tup_set = set(self.m.rxns2tuple((self.f.rns | self.seed.rns)))
-        scope_cpds, scope_rns = self.m.expand(seed.cpds, reaction_mask=rn_tup_set)
+        compound_iteration_dict, reaction_iteration_dict = self.m.expand(seed.cpds, reaction_mask=rn_tup_set, algorithm="trace")
 
         scope = Params()
-        scope.cpds = set(scope_cpds)
-        scope.rns = set([i[0] for i in scope_rns])
+        scope.cpd_iteration_dict, scope.rn_iteration_dict = compound_iteration_dict, {k[0]:v for k,v in reaction_iteration_dict.items()}
+        scope.cpds, scope.rns = set(scope.cpd_iteration_dict.keys()), set(scope.rn_iteration_dict.keys())
+
+        # scope.cpds = set(scope_cpds)
+        # scope.rns = set([i[0] for i in scope_rns])
         scope.rules = self.f.subset_from_rns(scope.rns)
         scope.folds = scope.rules.folds 
         print("...done.")
-        return ImmutableParams(folds=scope.folds, rns=scope.rns, rules=scope.rules, cpds=scope.cpds)
+        return ImmutableParams(folds=scope.folds, rns=scope.rns, rules=scope.rules, cpds=scope.cpds, cpd_iteration_dict=scope.cpd_iteration_dict, rn_iteration_dict=scope.rn_iteration_dict)
 
     def fold_expand(self, folds, current_cpds, fold_algorithm="trace"):
         """
@@ -811,7 +818,17 @@ class FoldMetabolism:
         else:
             return True
 
-    def rule_order(self, algorithm, write=False, write_tmp=False, path=None, str_to_append_to_fname=None, debug=False, ordered_outcome=False, ignore_reaction_versions=False):
+    def rule_order(
+        self, 
+        algorithm, 
+        write=False, 
+        write_tmp=False, 
+        path=None, 
+        str_to_append_to_fname=None, 
+        debug=False, 
+        ordered_outcome=False, 
+        ignore_reaction_versions=False,
+        write_max_effects = False):
         """
         Determine the ordering of all rules/folds.
 
@@ -862,7 +879,8 @@ class FoldMetabolism:
                 current.rns = effects.rns
                 current.rn_iteration_dict = effects.rn_iteration_dict
                 current.rules = self.scope.rules.subset_from_folds(current.folds).subset_from_rns(current.rns)
-                metadata.max_effects = max_effects
+                if write_max_effects: metadata.max_effects = max_effects 
+                metadata.eq_best_folds = set(max_effects.keys())
                 metadata.size2foldsets = size2foldsets
 
             ## Store when cpds and rns appear in the expansion


### PR DESCRIPTION
- Greatly reduces (by ~10x) default output file size by not writing `current` object after every step
- Adds a new attribute to results `eq_best_folds` which stores a set of best and equivalent foldsets, indexed by fold iteration
- Reduces and better formats default printing